### PR TITLE
fix: use-request auto collect deps first request twice

### DIFF
--- a/packages/hooks/src/useRequest/docs/refreshDeps/demo/demo1.vue
+++ b/packages/hooks/src/useRequest/docs/refreshDeps/demo/demo1.vue
@@ -4,7 +4,7 @@
       <vhp-button type="button" @click="count++">count is {{ count }}</vhp-button>
       <div style="opacity: 0.6;"> count !==0 and count !==5 ready is true </div>
     </div>
-    <br>
+    <br />
     <vhp-button @click="() => (id = 1)">Change ID = 1</vhp-button>
     <vhp-button @click="() => (id = 2)" style="margin-left: 16px;">Change ID = 2</vhp-button>
     <vhp-button @click="() => (store.id = 1)" style="margin-left: 16px;">
@@ -77,7 +77,7 @@
   })
   const count = ref(0)
 
-  const ready = computed(() => count.value !== undefined)
+  const ready = computed(() => count.value !== 0 && count.value !== 5)
   const { data, loading } = useRequest(
     () => getUsername({ id: id.value, storeId: store.id, count: count.value }),
     {
@@ -89,7 +89,6 @@
       },
       ready,
       refreshDeps: true,
-      debounceWait: 1000,
     },
   )
 </script>

--- a/packages/hooks/src/useRequest/plugins/useAutoRunPlugin.ts
+++ b/packages/hooks/src/useRequest/plugins/useAutoRunPlugin.ts
@@ -9,7 +9,7 @@ const useAutoRunPlugin: UseRequestPlugin<unknown, unknown[]> = (
   const hasAutoRun = ref(false)
 
   watchEffect(() => {
-    if (!manual) hasAutoRun.value = unref(ready)
+    if (!manual && fetchInstance.options.refreshDeps !== true) hasAutoRun.value = unref(ready)
   })
 
   if (refreshDeps instanceof Array)


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/InhiblabCore/vue-hooks-plus/tree/master/.github/PULL_REQUEST_TEMPLATE-zh-CN.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     fix use-request auto collect deps first request twice      |
| 🇨🇳 Chinese |    修复 use-request 自动依赖收集首次请求两次       |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Follow our [Code of Conduct](https://github.com/InhiblabCore/vue-hooks-plus/blob/master/CODE_OF_CONDUCT.md)
- [x] Read the [Contributing Guidelines](https://github.com/InhiblabCore/vue-hooks-plus/blob/master/CONTRIBUTING.md)
- [x] Read the [docs](https://inhiblabcore.github.io/docs/hooks)
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
