### PR TITLE
fix: 修复useRequest在启动两个以上轮询时，设置页面隐藏停止轮询，页面重新显示时，有请求不自动开始轮询的问题

### DIFF
--- a/packages/use-request/src/utils/subscribeFocus.ts
+++ b/packages/use-request/src/utils/subscribeFocus.ts
@@ -6,28 +6,25 @@ import isOnline from './isOnline'
 
 type Listener = () => void
 
-const listeners: Listener[] = []
+const listeners = new Set<Listener>();
 
 function subscribe(listener: Listener) {
-  listeners.push(listener)
+  listeners.add(listener);
+
   return function unsubscribe() {
-    const index = listeners.indexOf(listener)
-    if (index > -1) {
-      listeners.splice(index, 1)
-    }
-  }
+    listeners.has(listener) && listeners.delete(listener);
+  };
 }
 
 if (isBrowser) {
   const revalidate = () => {
     if (!isDocumentVisible() || !isOnline()) return
-    for (let i = 0; i < listeners.length; i++) {
-      const listener = listeners[i]
-      listener()
-    }
+    listeners.forEach(listener => {
+      listener();
+    })
   }
-  window.addEventListener('visibilitychange', revalidate, false)
-  window.addEventListener('focus', revalidate, false)
+  window.addEventListener('visibilitychange', revalidate, false);
+  window.addEventListener('focus', revalidate, false);
 }
 
 export default subscribe

--- a/packages/use-request/src/utils/subscribeReVisible.ts
+++ b/packages/use-request/src/utils/subscribeReVisible.ts
@@ -1,23 +1,23 @@
 import isDocumentVisible from "./isDocumentVisible";
 import { canUseDom } from "./utils";
 
-const listeners: any[] = [];
+type Listener = () => void;
 
-function subscribe(listener: () => void) {
-  listeners.push(listener);
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
   return function unsubscribe() {
-    const index = listeners.indexOf(listener);
-    listeners.splice(index, 1);
+    listeners.has(listener) && listeners.delete(listener);
   };
 }
 
 if (canUseDom()) {
   const revalidate = () => {
     if (!isDocumentVisible()) return;
-    for (let i = 0; i < listeners.length; i++) {
-      const listener = listeners[i];
+    listeners.forEach(listener => {
       listener();
-    }
+    });
   };
   window.addEventListener("visibilitychange", revalidate, false);
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄

New feature please send a pull request to master branch.
Pull requests will be merged after one of the collaborators approve.
Please makes sure that these forms are filled before submitting your pull request, thank you!
-->

[[中文版模板 / Chinese template](https://github.com/InhiblabCore/vue-hooks-plus/tree/master/.github/PULL_REQUEST_TEMPLATE-zh-CN.md)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

修复多个请求轮询时，设置了窗口不可见停止轮询，离开窗口再回 来，多个轮询请求只剩下一个请求继续轮询的问题（当前问题已在ahooks中修改一版并合入主分支 链接：https://github.com/alibaba/hooks/pull/2688）

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language     | Changelog |
| ------------ | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Follow our [Code of Conduct](https://github.com/InhiblabCore/vue-hooks-plus/blob/master/CODE_OF_CONDUCT.md)
- [x] Read the [Contributing Guidelines](https://github.com/InhiblabCore/vue-hooks-plus/blob/master/CONTRIBUTING.md)
- [x] Read the [docs](https://inhiblabcore.github.io/docs/hooks)
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed